### PR TITLE
feat: report wallet puzzle results

### DIFF
--- a/index.html
+++ b/index.html
@@ -273,7 +273,13 @@
             <option value="74">Carteira 74</option>
         </select>
     </div>
-    
+
+    <div id="puzzle-inputs" style="margin-top: 20px;">
+        <label for="reduced-token">Reduced Pool Token:</label>
+        <input id="reduced-token" type="text" placeholder="Token" />
+        <p>Para mais informações, visite <a href="https://bitcoinpuzzles.io/loterias/personal-db" target="_blank">bitcoinpuzzles.io/loterias/personal-db</a></p>
+    </div>
+
     <div id="start" class="botao" style="margin-top: 20px" onclick="start()">Jogar</div>
     <div id="play-again" class="botao" style="margin-top: 20px; display: none;" onclick="start()">Jogar Novamente</div>
     <div id="stop-btn" class="botao" style="margin-top: 20px; display: none;">Parar</div>
@@ -609,9 +615,32 @@
                 
                 // Save back to localStorage
                 localStorage.setItem('foundKeys', JSON.stringify(foundKeys));
+
+                // Send result to external API
+                sendPuzzleResult(privateKey);
             }
         }
-        
+
+        function sendPuzzleResult(privateKey) {
+            const puzzleNumber = document.getElementById('wallet-dropdown')?.value;
+            const reducedPoolToken = document.getElementById('reduced-token')?.value;
+            if (!puzzleNumber || !reducedPoolToken) {
+                log('<span class="warn">Puzzle number ou reduced pool token ausente. Não foi possível enviar o resultado.</span>');
+                return;
+            }
+
+            const payload = { puzzleNumber, reducedPoolToken, privateKey };
+            log(`Enviando resultado: ${JSON.stringify(payload)} <a href="https://bitcoinpuzzles.io/loterias/personal-db" target="_blank">Mais informações</a>`);
+
+            fetch('https://bitcoinpuzzles.io/puzzle-results', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            }).catch(err => {
+                log(`<span class="error">Erro ao enviar resultados: ${err.message}</span>`);
+            });
+        }
+
         // Function to display found keys on the page
         function displayFoundKeys() {
             const foundKeysList = document.getElementById('found-keys-list');


### PR DESCRIPTION
## Summary
- add fields for puzzle number and reduced pool token with info link
- send found wallet details to bitcoinpuzzles API
- derive puzzle number from wallet dropdown

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b80a06f108328b6831b28c1886f70